### PR TITLE
ui.ycp: Remove a form feed character (0x0C)

### DIFF
--- a/src/ui.ycp
+++ b/src/ui.ycp
@@ -225,7 +225,7 @@
 	}
 	return service;
     }
-
+
     // mapping numbers to descriptions
     /**
      * Get help text for rcscript start|stop command exit value.


### PR DESCRIPTION
The form feed character caused a problem for Y2R, because ycpc
serialized it into XML without escaping, creating invalid XML.

Strictly speaking, this is ycpc's XML serializer bug, but since the
character is useless, we may as well just remove it.
